### PR TITLE
Harden config parsing and fix model list typo

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,7 @@ else:
 
 # [step 3]>> 模型选择是 (注意: LLM_MODEL是默认选中的模型, 它*必须*被包含在AVAIL_LLM_MODELS列表中 )
 LLM_MODEL = "gpt-5-mini" # 可选 ↓↓↓
-AVAIL_LLM_MODELS = ["o1-mini","o1", "o3-mini", "o3"
+AVAIL_LLM_MODELS = ["o1-mini","o1", "o3-mini", "o3",
                     "gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-5", "gpt-5-chat", "gpt-5-mini",
                     "gpt-4", "gpt-4-32k", "azure-gpt-4", "glm-4", "glm-4v", "glm-3-turbo",
                     "aioagi-claude-sonnet-4", "aioagi-claude-opus-4", "aioagi-claude-3-7-sonnet", "aioagi-claude-3-5-sonnet", "aioagi-claude-3-5-haiku","aioagi-claude-sonnet-4-5",

--- a/shared_utils/config_loader.py
+++ b/shared_utils/config_loader.py
@@ -1,6 +1,7 @@
 import importlib
 import time
 import os
+import ast
 from functools import lru_cache
 from shared_utils.colorful import log亮红, log亮绿, log亮蓝
 
@@ -44,12 +45,12 @@ def read_env_variable(arg, default_value):
         elif isinstance(default_value, str):
             r = env_arg.strip()
         elif isinstance(default_value, dict):
-            r = eval(env_arg)
+            r = ast.literal_eval(env_arg)
         elif isinstance(default_value, list):
-            r = eval(env_arg)
+            r = ast.literal_eval(env_arg)
         elif default_value is None:
             assert arg == "proxies"
-            r = eval(env_arg)
+            r = ast.literal_eval(env_arg)
         else:
             log亮红(f"[ENV_VAR] 环境变量{arg}不支持通过环境变量设置! ")
             raise KeyError


### PR DESCRIPTION
## Summary

  - Fix a missing comma in `AVAIL_LLM_MODELS` that merged `"o3"` and `"gpt-4o"` into one invalid model name.
  - Replace `eval()` with `ast.literal_eval()` for environment-driven dict/list/proxies config parsing.

  ## Verification

  - Confirmed `config.AVAIL_LLM_MODELS[3:5] == ['o3', 'gpt-4o']`.
  - Verified `ast.literal_eval()` still parses current documented config styles, including trailing-comma dict/
  list values, tuple-list `AUTHENTICATION` style values, and `None` for `proxies`.
  - Verified an executable expression is rejected rather than executed.
  - Ran syntax checks for `config.py` and `shared_utils/config_loader.py`.