### PR TITLE
Refresh current model catalog

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,17 @@ else:
 
 # [step 3]>> 模型选择是 (注意: LLM_MODEL是默认选中的模型, 它*必须*被包含在AVAIL_LLM_MODELS列表中 )
 LLM_MODEL = "gpt-5-mini" # 可选 ↓↓↓
-AVAIL_LLM_MODELS = ["o1-mini","o1", "o3-mini", "o3",
+AVAIL_LLM_MODELS = [
+                    # 2026 年当前直连模型
+                    "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+                    "claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5",
+                    "gemini-3.5-flash", "gemini-3.1-flash-lite", "gemini-3.1-pro-preview",
+                    "kimi-k3", "kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6",
+                    "glm-5.2", "glm-5.1", "glm-5-turbo", "glm-4.7-flash",
+                    "qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash",
+                    "grok-4.5", "grok-4.3",
+                    # 保留原有模型，兼容已有部署和中转服务
+                    "o1-mini","o1", "o3-mini", "o3",
                     "gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-5", "gpt-5-chat", "gpt-5-mini",
                     "gpt-4", "gpt-4-32k", "azure-gpt-4", "glm-4", "glm-4v", "glm-3-turbo",
                     "aioagi-claude-sonnet-4", "aioagi-claude-opus-4", "aioagi-claude-3-7-sonnet", "aioagi-claude-3-5-sonnet", "aioagi-claude-3-5-haiku","aioagi-claude-sonnet-4-5",
@@ -47,15 +57,14 @@ AVAIL_LLM_MODELS = ["o1-mini","o1", "o3-mini", "o3",
 EMBEDDING_MODEL = "text-embedding-3-small"
 
 # --- --- --- ---
-# P.S. 其他可用的模型还包括
+# P.S. 其他兼容模型和特殊接入方式还包括
 # AVAIL_LLM_MODELS = [
 #   "glm-4-0520", "glm-4-air", "glm-4-airx", "glm-4-flash",
 #   "qianfan", "deepseekcoder",
 #   "spark", "sparkv2", "sparkv3", "sparkv3.5", "sparkv4",
 #   "qwen-turbo", "qwen-plus", "qwen-local",
-#   "moonshot-v1-128k", "moonshot-v1-32k", "moonshot-v1-8k",
+#   "moonshot-v1-128k", "moonshot-v1-32k", "moonshot-v1-8k",  # 旧账号兼容，计划于 2026-08-31 下线
 #   "gpt-3.5-turbo-0613", "gpt-3.5-turbo-16k-0613", "gpt-3.5-turbo-0125", "gpt-4o-2024-05-13"
-#   "claude-3-haiku-20240307","claude-3-sonnet-20240229","claude-3-opus-20240229", "claude-2.1", "claude-instant-1.2",
 #   "moss", "llama2", "chatglm_onnx", "internlm", "jittorllms_pangualpha", "jittorllms_llama",
 #   "deepseek-chat" ,"deepseek-coder",
 #   "gemini-1.5-flash",
@@ -153,7 +162,7 @@ DEFAULT_FN_GROUPS = ['对话', '编程', '学术', '智能体']
 
 
 # 定义界面上“询问多个GPT模型”插件应该使用哪些模型，请从AVAIL_LLM_MODELS中选择，并在不同模型之间用`&`间隔，例如"gpt-3.5-turbo&chatglm3&azure-gpt-4"
-MULTI_QUERY_LLM_MODELS = "gpt-5-chat&claude-sonnet-4-20250514"
+MULTI_QUERY_LLM_MODELS = "gpt-5.6-terra&claude-sonnet-5"
 
 
 # 选择本地模型变体（只有当AVAIL_LLM_MODELS包含了对应本地模型时，才会起作用）
@@ -258,6 +267,10 @@ ANTHROPIC_API_KEY = ""
 
 # 月之暗面 API KEY
 MOONSHOT_API_KEY = ""
+
+
+# 阿里云百炼（通义千问）API KEY
+DASHSCOPE_API_KEY = ""
 
 
 # 零一万物(Yi Model) API KEY
@@ -368,7 +381,7 @@ AUTO_CONTEXT_MAX_CLIP_RATIO = [0.80, 0.60, 0.45, 0.25, 0.20, 0.18, 0.16, 0.14, 0
 
 在线大模型配置关联关系示意图
 │
-├── "gpt-3.5-turbo" 等openai模型
+├── "gpt-5.6", "gpt-5.6-terra" 等 OpenAI 模型
 │   ├── API_KEY
 │   ├── CUSTOM_API_KEY_PATTERN（不常用）
 │   ├── API_ORG（不常用）
@@ -389,7 +402,7 @@ AUTO_CONTEXT_MAX_CLIP_RATIO = [0.80, 0.60, 0.45, 0.25, 0.20, 0.18, 0.16, 0.14, 0
 │   ├── XFYUN_API_SECRET
 │   └── XFYUN_API_KEY
 │
-├── "claude-3-opus-20240229" 等claude模型
+├── "claude-fable-5", "claude-sonnet-5" 等 Claude 模型
 │   └── ANTHROPIC_API_KEY
 │
 ├── "stack-claude"
@@ -401,17 +414,23 @@ AUTO_CONTEXT_MAX_CLIP_RATIO = [0.80, 0.60, 0.45, 0.25, 0.20, 0.18, 0.16, 0.14, 0
 │   ├── BAIDU_CLOUD_API_KEY
 │   └── BAIDU_CLOUD_SECRET_KEY
 │
-├── "glm-4", "glm-3-turbo", "zhipuai" 智谱AI大模型
+├── "glm-5.2", "glm-5.1" 等智谱 AI 大模型
 │   └── ZHIPUAI_API_KEY
 │
 ├── "yi-34b-chat-0205", "yi-34b-chat-200k" 等零一万物(Yi Model)大模型
 │   └── YIMODEL_API_KEY
 │
-├── "qwen-turbo" 等通义千问大模型
+├── "qwen3.7-max", "qwen3.7-plus" 等通义千问大模型
 │   └──  DASHSCOPE_API_KEY
 │
-├── "Gemini"
+├── "gemini-3.5-flash" 等 Gemini 模型
 │   └──  GEMINI_API_KEY
+│
+├── "kimi-k3", "kimi-k2.7-code" 等 Kimi 模型
+│   └──  MOONSHOT_API_KEY
+│
+├── "grok-4.5", "grok-4.3" 等 Grok 模型
+│   └──  GROK_API_KEY
 │
 └── "aioagi-...(max_token=...)" 用一种更方便的方式接入one-api多模型管理界面
     ├── AVAIL_LLM_MODELS

--- a/request_llms/bridge_all.py
+++ b/request_llms/bridge_all.py
@@ -45,6 +45,7 @@ from .bridge_cohere import predict as cohere_ui
 from .bridge_cohere import predict_no_ui_long_connection as cohere_noui
 
 from .oai_std_model_template import get_predict_function
+from .current_model_registry import CURRENT_MODEL_SPECS, current_model_names
 
 colors = ['#FF00FF', '#00FFFF', '#FF0000', '#990099', '#009999', '#990044']
 
@@ -110,6 +111,31 @@ tokenizer_gpt35 = LazyloadTiktoken("gpt-3.5-turbo")
 tokenizer_gpt4 = LazyloadTiktoken("gpt-4")
 get_token_num_gpt35 = lambda txt: len(tokenizer_gpt35.encode(txt, disallowed_special=()))
 get_token_num_gpt4 = lambda txt: len(tokenizer_gpt4.encode(txt, disallowed_special=()))
+
+
+def _build_current_model_info(
+    spec, fn_with_ui, fn_without_ui, endpoint, tokenizer, token_cnt,
+    can_multi_thread=None,
+):
+    info = {
+        "fn_with_ui": fn_with_ui,
+        "fn_without_ui": fn_without_ui,
+        "endpoint": endpoint,
+        "max_token": spec["max_token"],
+        "tokenizer": tokenizer,
+        "token_cnt": token_cnt,
+    }
+    if can_multi_thread is not None:
+        info["can_multi_thread"] = can_multi_thread
+    for attribute in (
+        "max_output_token",
+        "has_multimodal_capacity",
+        "enable_reasoning",
+        "omit_sampling_parameters",
+    ):
+        if attribute in spec:
+            info[attribute] = spec[attribute]
+    return info
 
 
 # 开始初始化模型
@@ -645,6 +671,25 @@ model_info = {
     },
 
 }
+
+for model_name, spec in CURRENT_MODEL_SPECS["openai"].items():
+    model_info[model_name] = _build_current_model_info(
+        spec, chatgpt_ui, chatgpt_noui, openai_endpoint,
+        tokenizer_gpt4, get_token_num_gpt4,
+    )
+
+for model_name, spec in CURRENT_MODEL_SPECS["gemini"].items():
+    model_info[model_name] = _build_current_model_info(
+        spec, genai_ui, genai_noui, gemini_endpoint,
+        tokenizer_gpt35, get_token_num_gpt35,
+    )
+
+for model_name, spec in CURRENT_MODEL_SPECS["glm"].items():
+    model_info[model_name] = _build_current_model_info(
+        spec, zhipu_ui, zhipu_noui, None,
+        tokenizer_gpt35, get_token_num_gpt35,
+    )
+
 # -=-=-=-=-=-=- 月之暗面 -=-=-=-=-=-=-
 from request_llms.bridge_moonshot import predict as moonshot_ui
 from request_llms.bridge_moonshot import predict_no_ui_long_connection as moonshot_no_ui
@@ -677,6 +722,11 @@ model_info.update({
         "token_cnt": get_token_num_gpt35,
     }
 })
+for model_name, spec in CURRENT_MODEL_SPECS["kimi"].items():
+    model_info[model_name] = _build_current_model_info(
+        spec, moonshot_ui, moonshot_no_ui, None,
+        tokenizer_gpt35, get_token_num_gpt35, can_multi_thread=True,
+    )
 # -=-=-=-=-=-=- api2d 对齐支持 -=-=-=-=-=-=-
 for model in AVAIL_LLM_MODELS:
     if model.startswith('api2d-') and (model.replace('api2d-','') in model_info.keys()):
@@ -705,7 +755,8 @@ claude_models = ["claude-instant-1.2",
                  "claude-opus-4-1",
                  "claude-sonnet-4",
                  "claude-sonnet-4-5",
-                 "claude-sonnet-4-5-thinking"]
+                 "claude-sonnet-4-5-thinking",
+                 *current_model_names("claude")]
 if any(item in claude_models for item in AVAIL_LLM_MODELS):
     from .bridge_claude import predict_no_ui_long_connection as claude_noui
     from .bridge_claude import predict as claude_ui
@@ -839,6 +890,11 @@ if any(item in claude_models for item in AVAIL_LLM_MODELS):
             "token_cnt": get_token_num_gpt35,
         },
     })
+    for model_name, spec in CURRENT_MODEL_SPECS["claude"].items():
+        model_info[model_name] = _build_current_model_info(
+            spec, claude_ui, claude_noui, claude_endpoint,
+            tokenizer_gpt35, get_token_num_gpt35,
+        )
 if "jittorllms_rwkv" in AVAIL_LLM_MODELS:
     from .bridge_jittorllms_rwkv import predict_no_ui_long_connection as rwkv_noui
     from .bridge_jittorllms_rwkv import predict as rwkv_ui
@@ -991,7 +1047,8 @@ if "qwen-local" in AVAIL_LLM_MODELS:
 # -=-=-=-=-=-=- 阿里云百炼（通义）-在线模型 -=-=-=-=-=-=-
 qwen_models = ["qwen-max-latest", "qwen-max-2025-01-25","qwen-max","qwen-turbo","qwen-plus",
                "dashscope-deepseek-r1","dashscope-deepseek-v3",
-               "dashscope-qwen3-14b", "dashscope-qwen3-235b-a22b", "dashscope-qwen3-qwen3-32b",
+               "dashscope-qwen3-14b", "dashscope-qwen3-235b-a22b", "dashscope-qwen3-32b",
+               *current_model_names("qwen"),
                ]
 if any(item in qwen_models for item in AVAIL_LLM_MODELS):
     try:
@@ -1091,6 +1148,11 @@ if any(item in qwen_models for item in AVAIL_LLM_MODELS):
                 "token_cnt": get_token_num_gpt35,
             }
         })
+        for model_name, spec in CURRENT_MODEL_SPECS["qwen"].items():
+            model_info[model_name] = _build_current_model_info(
+                spec, qwen_ui, qwen_noui, None,
+                tokenizer_gpt35, get_token_num_gpt35, can_multi_thread=True,
+            )
     except:
         logger.error(trimmed_format_exc())
 
@@ -1177,17 +1239,17 @@ if any(item in yi_models for item in AVAIL_LLM_MODELS):
 
 
 # -=-=-=-=-=-=- Grok model from x.ai -=-=-=-=-=-=-
-grok_models = ["grok-beta"]
+grok_models = ["grok-beta", *current_model_names("grok")]
 if any(item in grok_models for item in AVAIL_LLM_MODELS):
     try:
-        grok_beta_128k_noui, grok_beta_128k_ui = get_predict_function(
+        grok_noui, grok_ui = get_predict_function(
             api_key_conf_name="GROK_API_KEY", max_output_token=8192, disable_proxy=False
         )
 
         model_info.update({
             "grok-beta": {
-                "fn_with_ui": grok_beta_128k_ui,
-                "fn_without_ui": grok_beta_128k_noui,
+                "fn_with_ui": grok_ui,
+                "fn_without_ui": grok_noui,
                 "can_multi_thread": True,
                 "endpoint": grok_model_endpoint,
                 "max_token": 128000,
@@ -1196,6 +1258,11 @@ if any(item in grok_models for item in AVAIL_LLM_MODELS):
             },
 
         })
+        for model_name, spec in CURRENT_MODEL_SPECS["grok"].items():
+            model_info[model_name] = _build_current_model_info(
+                spec, grok_ui, grok_noui, grok_model_endpoint,
+                tokenizer_gpt35, get_token_num_gpt35, can_multi_thread=True,
+            )
     except:
         logger.error(trimmed_format_exc())
 

--- a/request_llms/bridge_chatgpt.py
+++ b/request_llms/bridge_chatgpt.py
@@ -23,6 +23,7 @@ from loguru import logger
 from toolbox import get_conf, update_ui, is_any_api_key, select_api_key, what_keys, clip_history
 from toolbox import trimmed_format_exc, is_the_upload_folder, read_one_api_model_name, log_chat
 from toolbox import ChatBotWithCookies, have_any_recent_upload_image_files, encode_image
+from .provider_compat import apply_openai_sampling_compatibility
 proxies, WHEN_TO_USE_PROXY, TIMEOUT_SECONDS, MAX_RETRY, API_ORG, AZURE_CFG_ARRAY = \
     get_conf('proxies', 'WHEN_TO_USE_PROXY', 'TIMEOUT_SECONDS', 'MAX_RETRY', 'API_ORG', 'AZURE_CFG_ARRAY')
 
@@ -618,8 +619,6 @@ def generate_payload(inputs:str, llm_kwargs:dict, history:list, system_prompt:st
         "n": 1,
         "stream": stream,
     }
-    openai_force_temperature_one = model_info[llm_kwargs['llm_model']].get('openai_force_temperature_one', False)
-    if openai_force_temperature_one:
-        payload.pop('temperature')
+    model_config = model_info[llm_kwargs['llm_model']]
+    apply_openai_sampling_compatibility(payload, model_config)
     return headers,payload
-

--- a/request_llms/bridge_claude.py
+++ b/request_llms/bridge_claude.py
@@ -16,9 +16,17 @@ import json
 import requests
 from loguru import logger
 from toolbox import get_conf, update_ui, trimmed_format_exc, encode_image, every_image_file_in_path, log_chat
+from .current_model_registry import current_model_names, omits_sampling_parameters
+from .provider_compat import extract_anthropic_text_delta
 
 picture_system_prompt = "\n当回复图像时,必须说明正在回复哪张图像。所有图像仅在最后一个问题中提供,即使它们在历史记录中被提及。请使用'这是第X张图像:'的格式来指明您正在描述的是哪张图像。"
-Claude_3_Models = ["claude-3-haiku-20240307", "claude-3-sonnet-20240229", "claude-3-opus-20240229", "claude-3-5-sonnet-20240620"]
+Claude_3_Models = [
+    "claude-3-haiku-20240307",
+    "claude-3-sonnet-20240229",
+    "claude-3-opus-20240229",
+    "claude-3-5-sonnet-20240620",
+    *current_model_names("claude"),
+]
 
 # config_private.py放自己的秘密如API和代理网址
 # 读取时首先看是否存在私密的config_private配置文件（不受git管控），如果有，则覆盖原config文件
@@ -120,12 +128,13 @@ def predict_no_ui_long_connection(inputs, llm_kwargs, history=[], sys_prompt="",
                     # logger.info(f'[response] {result}')
                     break
                 else:
-                    if chunkjson and chunkjson['type'] == 'content_block_delta':
-                        result += chunkjson['delta']['text']
+                    text_delta = extract_anthropic_text_delta(chunkjson)
+                    if text_delta:
+                        result += text_delta
                         if observe_window is not None:
                             # 观测窗，把已经获取的数据显示出去
                             if len(observe_window) >= 1:
-                                observe_window[0] += chunkjson['delta']['text']
+                                observe_window[0] += text_delta
                             # 看门狗，如果超过期限没有喂狗，则终止
                             if len(observe_window) >= 2:
                                 if (time.time()-observe_window[1]) > watch_dog_patience:
@@ -220,8 +229,9 @@ def predict(inputs, llm_kwargs, plugin_kwargs, chatbot, history=[], system_promp
                     # logger.info(f'[response] {gpt_replying_buffer}')
                     break
                 else:
-                    if chunkjson and chunkjson['type'] == 'content_block_delta':
-                        gpt_replying_buffer += chunkjson['delta']['text']
+                    text_delta = extract_anthropic_text_delta(chunkjson)
+                    if text_delta:
+                        gpt_replying_buffer += text_delta
                         history[-1] = gpt_replying_buffer
                         chatbot[-1] = (history[-2], history[-1])
                         yield from update_ui(chatbot=chatbot, history=history, msg='正常') # 刷新界面
@@ -302,8 +312,9 @@ def generate_payload(inputs, llm_kwargs, history, system_prompt, image_paths):
         'model': llm_kwargs['llm_model'],
         'max_tokens': 4096,
         'messages': messages,
-        'temperature': llm_kwargs['temperature'],
         'stream': True,
         'system': system_prompt
     }
+    if not omits_sampling_parameters("claude", llm_kwargs['llm_model']):
+        payload['temperature'] = llm_kwargs['temperature']
     return headers, payload

--- a/request_llms/bridge_moonshot.py
+++ b/request_llms/bridge_moonshot.py
@@ -10,6 +10,7 @@ from toolbox import get_conf, update_ui, log_chat
 from toolbox import ChatBotWithCookies
 
 import requests
+from .current_model_registry import omits_sampling_parameters
 
 
 class MoonShotInit:
@@ -91,11 +92,14 @@ class MoonShotInit:
         payload = {
             "model": self.llm_model,
             "messages": messages,
-            "temperature": llm_kwargs.get('temperature', 0.3),  # 1.0,
-            "top_p": llm_kwargs.get('top_p', 1.0),  # 1.0,
-            "n": llm_kwargs.get('n_choices', 1),
             "stream": stream
         }
+        if not omits_sampling_parameters("kimi", self.llm_model):
+            payload.update({
+                "temperature": llm_kwargs.get('temperature', 0.3),
+                "top_p": llm_kwargs.get('top_p', 1.0),
+                "n": llm_kwargs.get('n_choices', 1),
+            })
         return payload, header
 
     def generate_messages(self, inputs, llm_kwargs, history, system_prompt, stream):

--- a/request_llms/current_model_registry.py
+++ b/request_llms/current_model_registry.py
@@ -1,0 +1,155 @@
+"""Current first-party model IDs supported by the built-in provider bridges."""
+
+# Refresh this catalog against provider documentation when model lifecycles change.
+CATALOG_LAST_VERIFIED = "2026-07-17"
+
+CURRENT_MODEL_SPECS = {
+    "openai": {
+        "gpt-5.6": {
+            "max_token": 1_050_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+        "gpt-5.6-sol": {
+            "max_token": 1_050_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+        "gpt-5.6-terra": {
+            "max_token": 1_050_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+        "gpt-5.6-luna": {
+            "max_token": 1_050_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+    },
+    "claude": {
+        "claude-fable-5": {
+            "max_token": 1_000_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+        "claude-opus-4-8": {
+            "max_token": 1_000_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+        "claude-sonnet-5": {
+            "max_token": 1_000_000,
+            "max_output_token": 128_000,
+            "has_multimodal_capacity": True,
+            "omit_sampling_parameters": True,
+        },
+        "claude-haiku-4-5": {
+            "max_token": 200_000,
+            "max_output_token": 64_000,
+            "has_multimodal_capacity": True,
+        },
+        "claude-haiku-4-5-20251001": {
+            "max_token": 200_000,
+            "max_output_token": 64_000,
+            "has_multimodal_capacity": True,
+        },
+    },
+    "gemini": {
+        "gemini-3.5-flash": {
+            "max_token": 1_048_576,
+            "max_output_token": 65_536,
+            "has_multimodal_capacity": True,
+        },
+        "gemini-3.1-flash-lite": {
+            "max_token": 1_048_576,
+            "max_output_token": 65_536,
+            "has_multimodal_capacity": True,
+        },
+        "gemini-3.1-pro-preview": {
+            "max_token": 1_048_576,
+            "max_output_token": 65_536,
+            "has_multimodal_capacity": True,
+        },
+    },
+    "kimi": {
+        "kimi-k3": {
+            "max_token": 1_000_000,
+            "omit_sampling_parameters": True,
+        },
+        "kimi-k2.7-code": {
+            "max_token": 256_000,
+            "omit_sampling_parameters": True,
+        },
+        "kimi-k2.7-code-highspeed": {
+            "max_token": 256_000,
+            "omit_sampling_parameters": True,
+        },
+        "kimi-k2.6": {
+            "max_token": 256_000,
+            "omit_sampling_parameters": True,
+        },
+    },
+    "glm": {
+        "glm-5.2": {"max_token": 1_000_000, "max_output_token": 128_000},
+        "glm-5.1": {"max_token": 200_000, "max_output_token": 128_000},
+        "glm-5-turbo": {"max_token": 200_000, "max_output_token": 128_000},
+        "glm-4.7-flash": {"max_token": 200_000, "max_output_token": 128_000},
+    },
+    "qwen": {
+        "qwen3.7-max": {"max_token": 1_000_000},
+        "qwen3.7-plus": {"max_token": 1_000_000},
+        "qwen3.6-flash": {"max_token": 1_000_000},
+    },
+    "grok": {
+        "grok-4.5": {"max_token": 500_000, "enable_reasoning": True},
+        "grok-4.3": {"max_token": 1_000_000, "enable_reasoning": True},
+    },
+}
+
+
+DEFAULT_CURRENT_MODELS = (
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-haiku-4-5",
+    "gemini-3.5-flash",
+    "gemini-3.1-flash-lite",
+    "gemini-3.1-pro-preview",
+    "kimi-k3",
+    "kimi-k2.7-code",
+    "kimi-k2.7-code-highspeed",
+    "kimi-k2.6",
+    "glm-5.2",
+    "glm-5.1",
+    "glm-5-turbo",
+    "glm-4.7-flash",
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-flash",
+    "grok-4.5",
+    "grok-4.3",
+)
+
+
+def current_model_names(provider):
+    return tuple(CURRENT_MODEL_SPECS[provider])
+
+
+def get_current_model_spec(provider, model):
+    return CURRENT_MODEL_SPECS.get(provider, {}).get(model, {})
+
+
+def omits_sampling_parameters(provider, model):
+    return get_current_model_spec(provider, model).get(
+        "omit_sampling_parameters", False
+    )

--- a/request_llms/provider_compat.py
+++ b/request_llms/provider_compat.py
@@ -1,0 +1,29 @@
+"""Small payload and stream compatibility helpers shared by provider bridges."""
+
+
+def remove_request_parameters(payload, *parameter_names):
+    for parameter_name in parameter_names:
+        payload.pop(parameter_name, None)
+    return payload
+
+
+def apply_openai_sampling_compatibility(payload, model_config):
+    if model_config.get("omit_sampling_parameters", False):
+        return remove_request_parameters(payload, "temperature", "top_p")
+    if model_config.get("openai_force_temperature_one", False):
+        return remove_request_parameters(payload, "temperature")
+    return payload
+
+
+def extract_anthropic_text_delta(event):
+    if not isinstance(event, dict) or event.get("type") != "content_block_delta":
+        return ""
+
+    delta = event.get("delta")
+    if not isinstance(delta, dict):
+        return ""
+    if delta.get("type") not in (None, "text_delta"):
+        return ""
+
+    text = delta.get("text", "")
+    return text if isinstance(text, str) else ""

--- a/tests/test_current_model_catalog.py
+++ b/tests/test_current_model_catalog.py
@@ -1,0 +1,138 @@
+import ast
+import unittest
+from pathlib import Path
+
+from request_llms.current_model_registry import (
+    CURRENT_MODEL_SPECS,
+    DEFAULT_CURRENT_MODELS,
+    current_model_names,
+    omits_sampling_parameters,
+)
+from request_llms.provider_compat import (
+    apply_openai_sampling_compatibility,
+    extract_anthropic_text_delta,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_config_assignment(name):
+    tree = ast.parse((ROOT / "config.py").read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"Missing config assignment: {name}")
+
+
+class CurrentModelCatalogTests(unittest.TestCase):
+    def test_expected_current_models_are_registered(self):
+        expected = {
+            "openai": {"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"},
+            "claude": {
+                "claude-fable-5",
+                "claude-opus-4-8",
+                "claude-sonnet-5",
+                "claude-haiku-4-5",
+                "claude-haiku-4-5-20251001",
+            },
+            "gemini": {
+                "gemini-3.5-flash",
+                "gemini-3.1-flash-lite",
+                "gemini-3.1-pro-preview",
+            },
+            "kimi": {
+                "kimi-k3",
+                "kimi-k2.7-code",
+                "kimi-k2.7-code-highspeed",
+                "kimi-k2.6",
+            },
+            "glm": {"glm-5.2", "glm-5.1", "glm-5-turbo", "glm-4.7-flash"},
+            "qwen": {"qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash"},
+            "grok": {"grok-4.5", "grok-4.3"},
+        }
+
+        self.assertEqual(set(CURRENT_MODEL_SPECS), set(expected))
+        for provider, model_names in expected.items():
+            self.assertEqual(set(current_model_names(provider)), model_names)
+
+    def test_default_config_exposes_every_recommended_model_once(self):
+        configured_models = read_config_assignment("AVAIL_LLM_MODELS")
+        self.assertTrue(set(DEFAULT_CURRENT_MODELS).issubset(configured_models))
+        self.assertEqual(len(configured_models), len(set(configured_models)))
+
+    def test_multi_query_defaults_are_selectable(self):
+        configured_models = set(read_config_assignment("AVAIL_LLM_MODELS"))
+        multi_query_models = set(
+            read_config_assignment("MULTI_QUERY_LLM_MODELS").split("&")
+        )
+        self.assertTrue(multi_query_models.issubset(configured_models))
+
+    def test_model_ids_are_unique_across_providers(self):
+        model_names = [
+            model_name
+            for models in CURRENT_MODEL_SPECS.values()
+            for model_name in models
+        ]
+        self.assertEqual(len(model_names), len(set(model_names)))
+
+    def test_every_current_model_has_a_positive_context_window(self):
+        for provider, models in CURRENT_MODEL_SPECS.items():
+            for model_name, spec in models.items():
+                with self.subTest(provider=provider, model=model_name):
+                    self.assertGreater(spec["max_token"], 0)
+
+    def test_provider_bridges_consume_each_registry_group(self):
+        bridge_all = (ROOT / "request_llms" / "bridge_all.py").read_text(
+            encoding="utf-8"
+        )
+        for provider in CURRENT_MODEL_SPECS:
+            with self.subTest(provider=provider):
+                self.assertIn(f'CURRENT_MODEL_SPECS["{provider}"]', bridge_all)
+
+    def test_qwen_api_key_can_be_configured(self):
+        self.assertEqual(read_config_assignment("DASHSCOPE_API_KEY"), "")
+
+    def test_fixed_sampling_models_use_provider_defaults(self):
+        for model_name in current_model_names("openai"):
+            self.assertTrue(omits_sampling_parameters("openai", model_name))
+        for model_name in current_model_names("kimi"):
+            self.assertTrue(omits_sampling_parameters("kimi", model_name))
+        for model_name in ("claude-fable-5", "claude-opus-4-8", "claude-sonnet-5"):
+            self.assertTrue(omits_sampling_parameters("claude", model_name))
+
+
+class ProviderCompatibilityTests(unittest.TestCase):
+    def test_openai_current_models_drop_sampling_parameters(self):
+        payload = {"temperature": 0.2, "top_p": 0.9, "n": 1}
+        apply_openai_sampling_compatibility(
+            payload, {"omit_sampling_parameters": True}
+        )
+        self.assertEqual(payload, {"n": 1})
+
+    def test_legacy_openai_reasoning_flag_only_drops_temperature(self):
+        payload = {"temperature": 0.2, "top_p": 0.9}
+        apply_openai_sampling_compatibility(
+            payload, {"openai_force_temperature_one": True}
+        )
+        self.assertEqual(payload, {"top_p": 0.9})
+
+    def test_anthropic_text_delta_is_extracted(self):
+        event = {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "answer"},
+        }
+        self.assertEqual(extract_anthropic_text_delta(event), "answer")
+
+    def test_anthropic_thinking_delta_is_ignored(self):
+        event = {
+            "type": "content_block_delta",
+            "delta": {"type": "thinking_delta", "thinking": "private"},
+        }
+        self.assertEqual(extract_anthropic_text_delta(event), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a centralized catalog for current OpenAI, Claude, Gemini, Kimi, GLM, Qwen, and Grok model IDs
- register current models in provider bridges and expose them in the default model selector
- handle provider-specific request and streaming compatibility for GPT-5.6, current Claude models, and Kimi
- add the missing DashScope API key setting and fix the Qwen 3 model route typo

## Why
The default catalog mainly exposed older model generations. Adding IDs alone was insufficient because several current providers reject legacy sampling parameters or emit non-text reasoning stream events.

## Validation
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q config.py request_llms tests`
- `git diff --check`

## Notes
- Existing legacy model routes remain available for compatibility.
- Live provider requests were not run because API credentials are not available in this environment.